### PR TITLE
Modified MANIFEST.MF and removed META-INF/services

### DIFF
--- a/bundles/at.bestolution.efxclipse.icons.fontawsome/META-INF/MANIFEST.MF
+++ b/bundles/at.bestolution.efxclipse.icons.fontawsome/META-INF/MANIFEST.MF
@@ -7,5 +7,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fx.ui.controls;bundle-version="1.0.0"
 Service-Component: OSGI-INF/services/awesomeiconfontprovider.xml
-Require-Capability: osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"
-Provide-Capability: osgi.serviceloader; osgi.serviceloader=org.eclipse.fx.ui.controls.image.skin.spi.FontIconProvider
+Export-Package: at.bestolution.efxclipse.icons.fontawsome

--- a/bundles/at.bestolution.efxclipse.icons.fontawsome/META-INF/services/org.eclipse.fx.ui.controls.image.spi.IconFontProvider
+++ b/bundles/at.bestolution.efxclipse.icons.fontawsome/META-INF/services/org.eclipse.fx.ui.controls.image.spi.IconFontProvider
@@ -1,1 +1,0 @@
-at.bestolution.efxclipse.icons.fontawsome.AwesomeIconFontProvider


### PR DESCRIPTION
I wanted to use the AwesomeIcons map in an e4fx project, so I exported the main package.

```
Export-Package: at.bestolution.efxclipse.icons.fontawsome
```

I also removed the osgi.serviceloader since the service is already provides via ds and I was getting this error on startup:

```
org.eclipse.equinox.logger org.eclipse.osgi => Could not resolve module: at.bestolution.efxclipse.icons.fontawsome [2]
  Unresolved requirement: Require-Capability: osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"
```
